### PR TITLE
Add email alias management UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ sh <(curl https://raw.githubusercontent.com/usmannasir/cyberpanel/stable/preUpgr
 
 ## ✉️ Managing Email Aliases
 
-Use the `mailUtilities.py` helper to create or remove aliases:
+Email aliases can be managed from the CyberPanel UI under **Email → Email Aliases**.
+You can also use the `mailUtilities.py` helper to create or remove aliases:
 
 ```bash
 python plogical/mailUtilities.py createEmailAlias --alias sales@example.com --destination user@example.com

--- a/mailServer/mailserverManager.py
+++ b/mailServer/mailserverManager.py
@@ -1876,6 +1876,104 @@ milter_default_action = accept
             json_data = json.dumps(data_ret)
             return HttpResponse(json_data)
 
+    ### Email aliases
+    def emailAliases(self):
+        userID = self.request.session['userID']
+        currentACL = ACLManager.loadedACL(userID)
+
+        if not os.path.exists('/home/cyberpanel/postfix'):
+            proc = httpProc(self.request, 'mailServer/emailAliases.html',
+                            {"status": 0}, 'emailForwarding')
+            return proc.render()
+
+        websitesName = ACLManager.findAllSites(currentACL, userID)
+        websitesName = websitesName + ACLManager.findChildDomains(websitesName)
+
+        proc = httpProc(self.request, 'mailServer/emailAliases.html',
+                        {'websiteList': websitesName, "status": 1}, 'emailForwarding')
+        return proc.render()
+
+    def fetchEmailAliases(self):
+        try:
+            userID = self.request.session['userID']
+            currentACL = ACLManager.loadedACL(userID)
+            if ACLManager.currentContextPermission(currentACL, 'emailForwarding') == 0:
+                return ACLManager.loadErrorJson('fetchStatus', 0)
+
+            data = json.loads(self.request.body)
+            domain = data['domain']
+
+            admin = Administrator.objects.get(pk=userID)
+            if ACLManager.checkOwnership(domain, admin, currentACL) != 1:
+                return ACLManager.loadErrorJson()
+
+            status, records = mailUtilities.listEmailAliases(domain)
+            if status == 1:
+                final = {'status': 1, 'fetchStatus': 1, 'error_message': 'None', 'data': json.dumps(records)}
+            else:
+                final = {'status': 0, 'fetchStatus': 0, 'error_message': records}
+            return HttpResponse(json.dumps(final))
+
+        except BaseException as msg:
+            data_ret = {'status': 0, 'fetchStatus': 0, 'error_message': str(msg)}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+
+    def submitEmailAliasCreation(self):
+        try:
+            userID = self.request.session['userID']
+            currentACL = ACLManager.loadedACL(userID)
+            if ACLManager.currentContextPermission(currentACL, 'emailForwarding') == 0:
+                return ACLManager.loadErrorJson('createStatus', 0)
+
+            data = json.loads(self.request.body)
+            alias = data['alias'].lower()
+            destination = data['destination']
+
+            admin = Administrator.objects.get(pk=userID)
+            aliasDomain = alias.split('@')[1]
+            if ACLManager.checkOwnership(aliasDomain, admin, currentACL) != 1:
+                return ACLManager.loadErrorJson()
+
+            status, msg = mailUtilities.createEmailAlias(alias, destination)
+            if status == 1:
+                final = {'status': 1, 'createStatus': 1, 'successMessage': 'Successfully Created!', 'error_message': 'None'}
+            else:
+                final = {'status': 0, 'createStatus': 0, 'error_message': msg}
+            return HttpResponse(json.dumps(final))
+
+        except BaseException as msg:
+            data_ret = {'status': 0, 'createStatus': 0, 'error_message': str(msg)}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+
+    def submitEmailAliasDeletion(self):
+        try:
+            userID = self.request.session['userID']
+            currentACL = ACLManager.loadedACL(userID)
+            if ACLManager.currentContextPermission(currentACL, 'emailForwarding') == 0:
+                return ACLManager.loadErrorJson('deleteStatus', 0)
+
+            data = json.loads(self.request.body)
+            alias = data['alias']
+
+            admin = Administrator.objects.get(pk=userID)
+            aliasDomain = alias.split('@')[1]
+            if ACLManager.checkOwnership(aliasDomain, admin, currentACL) != 1:
+                return ACLManager.loadErrorJson()
+
+            status, msg = mailUtilities.deleteEmailAlias(alias)
+            if status == 1:
+                final = {'status': 1, 'deleteStatus': 1, 'successMessage': 'Successfully deleted!', 'error_message': 'None'}
+            else:
+                final = {'status': 0, 'deleteStatus': 0, 'error_message': msg}
+            return HttpResponse(json.dumps(final))
+
+        except BaseException as msg:
+            data_ret = {'status': 0, 'deleteStatus': 0, 'error_message': str(msg)}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+
 def main():
 
     parser = argparse.ArgumentParser(description='CyberPanel')

--- a/mailServer/static/mailServer/mailServer.js
+++ b/mailServer/static/mailServer/mailServer.js
@@ -1552,3 +1552,86 @@ app.controller('EmailLimitsNew', function ($scope, $http) {
 
 });
 /* Java script for EmailLimitsNew */
+/* Java script for managing email aliases */
+app.controller('emailAliases', function ($scope, $http) {
+    $scope.aliasBox = true;
+    $scope.aliasLoading = true;
+    $scope.aliasError = true;
+    $scope.aliasSuccess = true;
+    $scope.couldNotConnect = true;
+
+    $scope.loadAliases = function () {
+        $scope.aliasBox = true;
+        $scope.aliasLoading = false;
+        $scope.aliasError = true;
+        $scope.aliasSuccess = true;
+        $scope.couldNotConnect = true;
+
+        var url = "/email/fetchEmailAliases";
+        var data = { domain: $scope.selectedDomain };
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') } };
+        $http.post(url, data, config).then(function(response){
+            if (response.data.fetchStatus === 1) {
+                $scope.records = response.data.data ? JSON.parse(response.data.data) : [];
+                $scope.aliasBox = false;
+                $scope.aliasLoading = true;
+            } else {
+                $scope.aliasBox = true;
+                $scope.aliasLoading = true;
+                $scope.aliasError = false;
+                $scope.errorMessage = response.data.error_message;
+            }
+        }, function(){
+            $scope.aliasBox = true;
+            $scope.aliasLoading = true;
+            $scope.couldNotConnect = false;
+        });
+    };
+
+    $scope.createAlias = function () {
+        $scope.aliasLoading = false;
+        var url = "/email/submitEmailAliasCreation";
+        var data = { alias: $scope.alias, destination: $scope.destination };
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') } };
+        $http.post(url, data, config).then(function(response){
+            $scope.aliasLoading = true;
+            if (response.data.createStatus === 1) {
+                $scope.aliasError = true;
+                $scope.aliasSuccess = false;
+                $scope.successMessage = response.data.successMessage;
+                $scope.loadAliases();
+            } else {
+                $scope.aliasError = false;
+                $scope.aliasSuccess = true;
+                $scope.errorMessage = response.data.error_message;
+            }
+        }, function(){
+            $scope.aliasLoading = true;
+            $scope.couldNotConnect = false;
+        });
+    };
+
+    $scope.deleteAlias = function (alias) {
+        $scope.aliasLoading = false;
+        var url = "/email/submitEmailAliasDeletion";
+        var data = { alias: alias };
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') } };
+        $http.post(url, data, config).then(function(response){
+            $scope.aliasLoading = true;
+            if (response.data.deleteStatus === 1) {
+                $scope.aliasError = true;
+                $scope.aliasSuccess = false;
+                $scope.successMessage = response.data.successMessage;
+                $scope.loadAliases();
+            } else {
+                $scope.aliasError = false;
+                $scope.aliasSuccess = true;
+                $scope.errorMessage = response.data.error_message;
+            }
+        }, function(){
+            $scope.aliasLoading = true;
+            $scope.couldNotConnect = false;
+        });
+    };
+});
+/* Java script for managing email aliases end */

--- a/mailServer/templates/mailServer/emailAliases.html
+++ b/mailServer/templates/mailServer/emailAliases.html
@@ -1,0 +1,94 @@
+{% extends "baseTemplate/index.html" %}
+{% load i18n %}
+{% block title %}{% trans "Manage Email Aliases - CyberPanel" %}{% endblock %}
+{% block content %}
+    {% load static %}
+    {% get_current_language as LANGUAGE_CODE %}
+    <!-- Current language: {{ LANGUAGE_CODE }} -->
+    <div class="container">
+        <div id="page-title">
+            <h2>{% trans "Manage Email Aliases" %}</h2>
+            <p>{% trans "Create or remove email address aliases." %}</p>
+        </div>
+        <div ng-controller="emailAliases" class="panel">
+            <div class="panel-body">
+                <h3 class="content-box-header">
+                    {% trans "Manage Email Aliases" %} <img ng-hide="aliasLoading" src="{% static 'images/loading.gif' %}">
+                </h3>
+                <div class="example-box-wrapper">
+                    {% if not status %}
+                        <div class="col-md-12 text-center" style="margin-bottom: 2%;">
+                            <h3>{% trans "Postfix is disabled." %}
+                                <a href="{% url 'managePostfix' %}">
+                                    <button class="btn btn-alt btn-hover btn-blue-alt">
+                                        <span>{% trans "Enable Now" %}</span>
+                                        <i class="glyph-icon icon-arrow-right"></i>
+                                    </button>
+                                </a></h3>
+                        </div>
+                    {% else %}
+                        <form action="/" class="form-horizontal bordered-row">
+                            <div class="form-group">
+                                <label class="col-sm-3 control-label">{% trans "Select Domain" %}</label>
+                                <div class="col-sm-6">
+                                    <select ng-change="loadAliases()" ng-model="selectedDomain" class="form-control">
+                                        {% for items in websiteList %}
+                                            <option>{{ items }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                            </div>
+                            <div ng-hide="aliasBox" class="form-group">
+                                <label class="col-sm-3 control-label"></label>
+                                <div class="col-sm-4">
+                                    <div ng-hide="aliasError" class="alert alert-danger">
+                                        <p>{$ errorMessage $}</p>
+                                    </div>
+                                    <div ng-hide="aliasSuccess" class="alert alert-success">
+                                        <p>{$ successMessage $}</p>
+                                    </div>
+                                    <div ng-hide="couldNotConnect" class="alert alert-danger">
+                                        <p>{% trans "Could not connect to server. Please refresh this page." %}</p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div ng-hide="aliasBox" class="form-group">
+                                <div class="col-sm-4">
+                                    <input placeholder="{% trans 'Alias address' %}" type="email" class="form-control" ng-model="alias">
+                                </div>
+                                <div class="col-sm-4">
+                                    <input placeholder="{% trans 'Destination' %}" type="text" class="form-control" ng-model="destination">
+                                </div>
+                                <div class="col-sm-4">
+                                    <button style="width: 100%;" type="button" ng-click="createAlias()" class="btn btn-primary">{% trans "Create Alias" %}</button>
+                                </div>
+                            </div>
+                            <div ng-hide="aliasBox" class="form-group">
+                                <div class="col-sm-12">
+                                    <table class="table">
+                                        <thead>
+                                        <tr>
+                                            <th>{% trans "ID" %}</th>
+                                            <th>{% trans "Alias" %}</th>
+                                            <th>{% trans "Destination" %}</th>
+                                            <th>{% trans "Actions" %}</th>
+                                        </tr>
+                                        </thead>
+                                        <tbody>
+                                        <tr ng-repeat="record in records track by $index">
+                                            <td ng-bind="$index + 1"></td>
+                                            <td ng-bind="record.source"></td>
+                                            <td ng-bind="record.destination"></td>
+                                            <td ng-click="deleteAlias(record.source)"><img src="{% static 'images/delete.png' %}"></td>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </form>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/mailServer/urls.py
+++ b/mailServer/urls.py
@@ -14,6 +14,12 @@ urlpatterns = [
     re_path(r'^fetchCurrentForwardings$', views.fetchCurrentForwardings, name='fetchCurrentForwardings'),
     re_path(r'^submitForwardDeletion$', views.submitForwardDeletion, name='submitForwardDeletion'),
 
+    ## Email Aliases
+    re_path(r'^emailAliases$', views.emailAliases, name='emailAliases'),
+    re_path(r'^fetchEmailAliases$', views.fetchEmailAliases, name='fetchEmailAliases'),
+    re_path(r'^submitEmailAliasCreation$', views.submitEmailAliasCreation, name='submitEmailAliasCreation'),
+    re_path(r'^submitEmailAliasDeletion$', views.submitEmailAliasDeletion, name='submitEmailAliasDeletion'),
+
     ## Delete email
     re_path(r'^deleteEmailAccount$', views.deleteEmailAccount, name='deleteEmailAccount'),
     re_path(r'^getEmailsForDomain$', views.getEmailsForDomain, name='getEmailsForDomain'),

--- a/mailServer/views.py
+++ b/mailServer/views.py
@@ -263,4 +263,39 @@ def SaveEmailLimitsNew(request):
         return HttpResponse(json_data)
 
 
+def emailAliases(request):
+    try:
+        msM = MailServerManager(request)
+        return msM.emailAliases()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def fetchEmailAliases(request):
+    try:
+        msM = MailServerManager(request)
+        return msM.fetchEmailAliases()
+    except KeyError as msg:
+        data_ret = {'fetchStatus': 0, 'error_message': str(msg)}
+        json_data = json.dumps(data_ret)
+        return HttpResponse(json_data)
+
+def submitEmailAliasCreation(request):
+    try:
+        msM = MailServerManager(request)
+        return msM.submitEmailAliasCreation()
+    except KeyError as msg:
+        data_ret = {'createStatus': 0, 'error_message': str(msg)}
+        json_data = json.dumps(data_ret)
+        return HttpResponse(json_data)
+
+def submitEmailAliasDeletion(request):
+    try:
+        msM = MailServerManager(request)
+        return msM.submitEmailAliasDeletion()
+    except KeyError as msg:
+        data_ret = {'deleteStatus': 0, 'error_message': str(msg)}
+        json_data = json.dumps(data_ret)
+        return HttpResponse(json_data)
+
+
 


### PR DESCRIPTION
## Summary
- add templates and JS for managing email aliases
- support alias create/delete/list in backend
- wire up new URLs and views
- document email alias UI usage in README

## Testing
- `pytest -q`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6845d59194a88323a194995e4db0a216