### PR TITLE
Add email alias management

### DIFF
--- a/baseTemplate/static/baseTemplate/custom-js/system-status.js
+++ b/baseTemplate/static/baseTemplate/custom-js/system-status.js
@@ -275,6 +275,7 @@ app.controller('adminController', function ($scope, $http, $timeout) {
 
             if (!Boolean(response.data.emailForwarding)) {
                 $('.emailForwarding').hide();
+                $('.emailAliases').hide();
             }
 
             if (!Boolean(response.data.changeEmailPassword)) {

--- a/baseTemplate/templates/baseTemplate/index.html
+++ b/baseTemplate/templates/baseTemplate/index.html
@@ -596,6 +596,11 @@
                                                    title="{% trans 'Email Forwarding' %}"><span>{% trans "Email Forwarding" %}</span></a>
                                             </li>
                                         {% endif %}
+                                        {% if admin or emailForwarding %}
+                                            <li class="emailAliases"><a href="{% url 'emailAliases' %}"
+                                                   title="{% trans 'Email Aliases' %}"><span>{% trans "Email Aliases" %}</span></a>
+                                            </li>
+                                        {% endif %}
                                         {% if admin or changeEmailPassword %}
                                             <li><a href="{% url 'changeEmailAccountPassword' %}"
                                                    title="{% trans 'Change Password' %}"><span>{% trans "Change Password" %}</span></a>

--- a/mailServer/mailserverManager.py
+++ b/mailServer/mailserverManager.py
@@ -535,6 +535,134 @@ class MailServerManager(multi.Thread):
             json_data = json.dumps(data_ret)
             return HttpResponse(json_data)
 
+    def emailAliases(self):
+        userID = self.request.session['userID']
+        currentACL = ACLManager.loadedACL(userID)
+
+        if not os.path.exists('/home/cyberpanel/postfix'):
+            proc = httpProc(self.request, 'mailServer/emailAliases.html',
+                            {"status": 0}, 'emailAliases')
+            return proc.render()
+
+        websitesName = ACLManager.findAllSites(currentACL, userID)
+        websitesName = websitesName + ACLManager.findChildDomains(websitesName)
+
+        proc = httpProc(self.request, 'mailServer/emailAliases.html',
+                        {'websiteList': websitesName, "status": 1}, 'emailAliases')
+        return proc.render()
+
+    def fetchCurrentAliases(self):
+        try:
+            userID = self.request.session['userID']
+            currentACL = ACLManager.loadedACL(userID)
+
+            if ACLManager.currentContextPermission(currentACL, 'emailForwarding') == 0:
+                return ACLManager.loadErrorJson('fetchStatus', 0)
+
+            data = json.loads(self.request.body)
+            domain = data['domain']
+
+            admin = Administrator.objects.get(pk=userID)
+            if ACLManager.checkOwnership(domain, admin, currentACL) != 1:
+                return ACLManager.loadErrorJson()
+
+            aliases = Forwardings.objects.filter(source__endswith='@' + domain)
+
+            json_data = "["
+            checker = 0
+            id = 1
+            for items in aliases:
+                if EUsers.objects.filter(email=items.source).count() > 0:
+                    continue
+                if items.source == items.destination:
+                    continue
+                dic = {'id': id,
+                       'source': items.source,
+                       'destination': items.destination}
+
+                id = id + 1
+
+                if checker == 0:
+                    json_data = json_data + json.dumps(dic)
+                    checker = 1
+                else:
+                    json_data = json_data + ',' + json.dumps(dic)
+
+            json_data = json_data + ']'
+            final_dic = {'status': 1, 'fetchStatus': 1, 'error_message': "None", 'data': json_data}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+        except BaseException as msg:
+            data_ret = {'status': 0, 'fetchStatus': 0, 'error_message': str(msg)}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+
+    def submitAliasDeletion(self):
+        try:
+            userID = self.request.session['userID']
+            currentACL = ACLManager.loadedACL(userID)
+            if ACLManager.currentContextPermission(currentACL, 'emailForwarding') == 0:
+                return ACLManager.loadErrorJson('deleteStatus', 0)
+
+            data = json.loads(self.request.body)
+            alias = data['alias']
+            destination = data['destination']
+            domain = alias.split('@')[1]
+
+            admin = Administrator.objects.get(pk=userID)
+            if ACLManager.checkOwnership(domain, admin, currentACL) != 1:
+                return ACLManager.loadErrorJson()
+
+            for item in Forwardings.objects.filter(source=alias, destination=destination):
+                item.delete()
+
+            data_ret = {'status': 1, 'deleteStatus': 1, 'error_message': "None", 'successMessage': 'Successfully deleted!'}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+
+        except BaseException as msg:
+            data_ret = {'status': 0, 'deleteStatus': 0, 'error_message': str(msg)}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+
+    def submitAliasCreation(self):
+        try:
+            userID = self.request.session['userID']
+            currentACL = ACLManager.loadedACL(userID)
+            if ACLManager.currentContextPermission(currentACL, 'emailForwarding') == 0:
+                return ACLManager.loadErrorJson('createStatus', 0)
+
+            data = json.loads(self.request.body)
+            alias = data['alias']
+            domain = data['domain']
+            destination = data['destination']
+
+            if '@' not in alias:
+                alias = f'{alias}@{domain}'
+
+            admin = Administrator.objects.get(pk=userID)
+            if ACLManager.checkOwnership(domain, admin, currentACL) != 1:
+                return ACLManager.loadErrorJson()
+
+            if EUsers.objects.filter(email=alias).count() > 0:
+                return ACLManager.loadErrorJson('createStatus', 0)
+
+            if Forwardings.objects.filter(source=alias, destination=destination).count() > 0:
+                return ACLManager.loadErrorJson('createStatus', 0)
+
+            forwarding = Forwardings(source=alias, destination=destination)
+            forwarding.save()
+
+            data_ret = {'status': 1, 'createStatus': 1, 'error_message': "None", 'successMessage': 'Successfully Created!'}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+
+        except BaseException as msg:
+            data_ret = {'status': 0, 'createStatus': 0, 'error_message': str(msg)}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+
     def fetchEmails(self):
         try:
             userID = self.request.session['userID']

--- a/mailServer/templates/mailServer/emailAliases.html
+++ b/mailServer/templates/mailServer/emailAliases.html
@@ -1,0 +1,79 @@
+{% extends "baseTemplate/index.html" %}
+{% load i18n %}
+{% block title %}{% trans "Manage Email Aliases - CyberPanel" %}{% endblock %}
+{% block content %}
+{% load static %}
+<div class="container">
+    <div id="page-title">
+        <h2>{% trans "Manage Email Aliases" %}</h2>
+        <p>{% trans "Create or remove email aliases." %}</p>
+    </div>
+    <div ng-controller="emailAliases" class="panel">
+        <div class="panel-body">
+            <h3 class="content-box-header">
+                {% trans "Email Aliases" %} <img ng-hide="aliasLoading" src="{% static 'images/loading.gif' %}">
+            </h3>
+            <div class="example-box-wrapper">
+            {% if not status %}
+                <div class="col-md-12 text-center" style="margin-bottom: 2%;">
+                    <h3>{% trans "Postfix is disabled." %}</h3>
+                </div>
+            {% else %}
+                <form action="/" class="form-horizontal bordered-row panel-body">
+                    <div class="form-group">
+                        <label class="col-sm-3 control-label">{% trans "Select Website" %}</label>
+                        <div class="col-sm-6">
+                            <select ng-change="fetchAliases()" ng-model="emailDomain" class="form-control">
+                                {% for items in websiteList %}
+                                    <option>{{ items }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                    </div>
+                    <div ng-hide="aliasDetails" class="form-group">
+                        <label class="col-sm-3 control-label">{% trans "Alias" %}</label>
+                        <div class="col-sm-6">
+                            <input type="text" class="form-control" ng-model="aliasName" placeholder="{% trans 'alias' %}">
+                        </div>
+                    </div>
+                    <div ng-hide="aliasDetails" class="form-group">
+                        <label class="col-sm-3 control-label">{% trans "Destination" %}</label>
+                        <div class="col-sm-6">
+                            <input type="text" class="form-control" ng-model="destinationEmail" placeholder="{% trans 'Destination' %}">
+                        </div>
+                    </div>
+                    <div ng-hide="aliasDetails" class="form-group">
+                        <label class="col-sm-3 control-label"></label>
+                        <div class="col-sm-4">
+                            <button type="button" ng-click="createAlias()" class="btn btn-primary" style="width:100%;">{% trans "Create Alias" %}</button>
+                        </div>
+                    </div>
+                    <div ng-hide="aliasList" class="form-group">
+                        <div class="col-sm-12">
+                            <table class="table">
+                                <thead>
+                                <tr>
+                                    <th>{% trans "ID" %}</th>
+                                    <th>{% trans "Alias" %}</th>
+                                    <th>{% trans "Destination" %}</th>
+                                    <th>{% trans "Actions" %}</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr ng-repeat="record in records track by $index">
+                                    <td ng-bind="record.id"></td>
+                                    <td ng-bind="record.source"></td>
+                                    <td ng-bind="record.destination"></td>
+                                    <td ng-click="deleteAlias(record.source, record.destination)"><img src="{% static 'images/delete.png' %}"></td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </form>
+            {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/mailServer/urls.py
+++ b/mailServer/urls.py
@@ -14,6 +14,12 @@ urlpatterns = [
     re_path(r'^fetchCurrentForwardings$', views.fetchCurrentForwardings, name='fetchCurrentForwardings'),
     re_path(r'^submitForwardDeletion$', views.submitForwardDeletion, name='submitForwardDeletion'),
 
+    ## Email Aliases
+    re_path(r'^emailAliases$', views.emailAliases, name='emailAliases'),
+    re_path(r'^fetchCurrentAliases$', views.fetchCurrentAliases, name='fetchCurrentAliases'),
+    re_path(r'^submitAliasCreation$', views.submitAliasCreation, name='submitAliasCreation'),
+    re_path(r'^submitAliasDeletion$', views.submitAliasDeletion, name='submitAliasDeletion'),
+
     ## Delete email
     re_path(r'^deleteEmailAccount$', views.deleteEmailAccount, name='deleteEmailAccount'),
     re_path(r'^getEmailsForDomain$', views.getEmailsForDomain, name='getEmailsForDomain'),

--- a/mailServer/views.py
+++ b/mailServer/views.py
@@ -161,6 +161,44 @@ def submitEmailForwardingCreation(request):
 
 #######
 
+def emailAliases(request):
+    try:
+        msM = MailServerManager(request)
+        return msM.emailAliases()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def fetchCurrentAliases(request):
+    try:
+        msM = MailServerManager(request)
+        return msM.fetchCurrentAliases()
+    except KeyError as msg:
+        data_ret = {'fetchStatus': 0, 'error_message': str(msg)}
+        json_data = json.dumps(data_ret)
+        return HttpResponse(json_data)
+
+def submitAliasDeletion(request):
+    try:
+
+        msM = MailServerManager(request)
+        return msM.submitAliasDeletion()
+    except KeyError as msg:
+        data_ret = {'deleteStatus': 0, 'error_message': str(msg)}
+        json_data = json.dumps(data_ret)
+        return HttpResponse(json_data)
+
+def submitAliasCreation(request):
+    try:
+
+        msM = MailServerManager(request)
+        return msM.submitAliasCreation()
+    except KeyError as msg:
+        data_ret = {'createStatus': 0, 'error_message': str(msg)}
+        json_data = json.dumps(data_ret)
+        return HttpResponse(json_data)
+
+#######
+
 def changeEmailAccountPassword(request):
     try:
         msM = MailServerManager(request)

--- a/static/mailServer/mailServer.js
+++ b/static/mailServer/mailServer.js
@@ -1345,3 +1345,79 @@ app.controller('listEmails', function ($scope, $http) {
 
 
 /* Java script code for List Emails Ends here */
+
+/* Java script code for email aliases */
+app.controller('emailAliases', function ($scope, $http) {
+
+    $scope.aliasDetails = true;
+    $scope.aliasLoading = true;
+    $scope.aliasList = true;
+
+    $scope.fetchAliases = function () {
+        if (!$scope.emailDomain) {
+            return;
+        }
+        $scope.aliasLoading = false;
+        $scope.aliasList = true;
+
+        var url = "/email/fetchCurrentAliases";
+        var data = {domain: $scope.emailDomain};
+        var config = {headers: {'X-CSRFToken': getCookie('csrftoken')}};
+
+        $http.post(url, data, config).then(function (response) {
+            $scope.aliasLoading = true;
+            if (response.data.fetchStatus === 1) {
+                $scope.records = JSON.parse(response.data.data);
+                $scope.aliasList = false;
+            } else {
+                new PNotify({title: 'Error!', text: response.data.error_message, type: 'error'});
+            }
+        }, function () {
+            $scope.aliasLoading = true;
+            new PNotify({title: 'Error!', text: 'Could not connect to server, please refresh this page.', type: 'error'});
+        });
+    };
+
+    $scope.createAlias = function () {
+        $scope.aliasLoading = false;
+
+        var url = "/email/submitAliasCreation";
+        var data = {domain: $scope.emailDomain, alias: $scope.aliasName, destination: $scope.destinationEmail};
+        var config = {headers: {'X-CSRFToken': getCookie('csrftoken')}};
+
+        $http.post(url, data, config).then(function (response) {
+            $scope.aliasLoading = true;
+            if (response.data.createStatus === 1) {
+                $scope.aliasName = '';
+                $scope.destinationEmail = '';
+                $scope.fetchAliases();
+            } else {
+                new PNotify({title: 'Error!', text: response.data.error_message, type: 'error'});
+            }
+        }, function () {
+            $scope.aliasLoading = true;
+            new PNotify({title: 'Error!', text: 'Could not connect to server, please refresh this page.', type: 'error'});
+        });
+    };
+
+    $scope.deleteAlias = function (source, destination) {
+        $scope.aliasLoading = false;
+
+        var url = "/email/submitAliasDeletion";
+        var data = {alias: source, destination: destination};
+        var config = {headers: {'X-CSRFToken': getCookie('csrftoken')}};
+
+        $http.post(url, data, config).then(function (response) {
+            $scope.aliasLoading = true;
+            if (response.data.deleteStatus === 1) {
+                $scope.fetchAliases();
+            } else {
+                new PNotify({title: 'Error!', text: response.data.error_message, type: 'error'});
+            }
+        }, function () {
+            $scope.aliasLoading = true;
+            new PNotify({title: 'Error!', text: 'Could not connect to server, please refresh this page.', type: 'error'});
+        });
+    };
+});
+


### PR DESCRIPTION
## Summary
- add Email Aliases page to the menu
- hide menu item based on ACL flag
- expose alias CRUD endpoints
- implement alias handling in MailServer manager
- add frontend Angular controller to manage aliases

## Testing
- `python3 -m py_compile mailServer/views.py mailServer/mailserverManager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d9238dac8323b5a55abc6dc98272