### PR TITLE
Add email alias plugin

### DIFF
--- a/CyberCP/settings.py
+++ b/CyberCP/settings.py
@@ -56,6 +56,7 @@ INSTALLED_APPS = [
     'filemanager',
     'manageServices',
     'pluginHolder',
+    'emailAliasPlugin',
     'emailPremium',
     'emailMarketing',
     'cloudAPI',

--- a/CyberCP/urls.py
+++ b/CyberCP/urls.py
@@ -38,6 +38,7 @@ urlpatterns = [
     path('emailPremium/', include('emailPremium.urls')),
     path('manageservices/', include('manageServices.urls')),
     path('plugins/', include('pluginHolder.urls')),
+    path('emailAliases/', include('emailAliasPlugin.urls')),
     path('emailMarketing/', include('emailMarketing.urls')),
     path('cloudAPI/', include('cloudAPI.urls')),
     path('docker/', include('dockerManager.urls')),

--- a/emailAliasPlugin/__init__.py
+++ b/emailAliasPlugin/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'emailAliasPlugin.apps.EmailaliaspluginConfig'

--- a/emailAliasPlugin/admin.py
+++ b/emailAliasPlugin/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# No custom admin models

--- a/emailAliasPlugin/apps.py
+++ b/emailAliasPlugin/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class EmailaliaspluginConfig(AppConfig):
+    name = 'emailAliasPlugin'

--- a/emailAliasPlugin/meta.xml
+++ b/emailAliasPlugin/meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cyberpanelPluginConfig>
+    <name>emailAliasPlugin</name>
+    <type>plugin</type>
+    <description>Manage email aliases</description>
+    <version>1</version>
+</cyberpanelPluginConfig>

--- a/emailAliasPlugin/models.py
+++ b/emailAliasPlugin/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# This plugin uses models from the mailServer app.

--- a/emailAliasPlugin/static/emailAliasPlugin/email_aliases.js
+++ b/emailAliasPlugin/static/emailAliasPlugin/email_aliases.js
@@ -1,0 +1,47 @@
+document.addEventListener('DOMContentLoaded', function () {
+    new Vue({
+        el: '#emailAliasApp',
+        delimiters: ['[[', ']]'],
+        data: {
+            aliases: [],
+            newSource: '',
+            newDestination: '',
+            error: '',
+            success: ''
+        },
+        methods: {
+            fetchAliases() {
+                fetch('fetch/', {method: 'POST'})
+                    .then(r => r.json())
+                    .then(data => { this.aliases = data.aliases; });
+            },
+            addAlias() {
+                this.error = '';
+                this.success = '';
+                fetch('add/', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({source: this.newSource, destination: this.newDestination})
+                }).then(r => r.json()).then(data => {
+                    if (data.status) {
+                        this.success = data.message;
+                        this.newDestination = '';
+                        this.fetchAliases();
+                    } else {
+                        this.error = data.error;
+                    }
+                });
+            },
+            deleteAlias(src, dst) {
+                fetch('delete/', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({source: src, destination: dst})
+                }).then(() => this.fetchAliases());
+            }
+        },
+        mounted() {
+            this.fetchAliases();
+        }
+    });
+});

--- a/emailAliasPlugin/templates/emailAliasPlugin/email_aliases.html
+++ b/emailAliasPlugin/templates/emailAliasPlugin/email_aliases.html
@@ -1,0 +1,42 @@
+{% extends "baseTemplate/index.html" %}
+{% load static i18n %}
+{% block title %}{% trans "Email Aliases" %}{% endblock %}
+{% block content %}
+<div class="container" id="emailAliasApp">
+    <div id="page-title">
+        <h2>{% trans "Email Aliases" %}</h2>
+        <p>{% trans "Manage email alias addresses." %}</p>
+    </div>
+    <div class="panel">
+        <div class="panel-body">
+            <div class="form-group">
+                <input type="email" class="form-control" placeholder="{% trans 'Alias address' %}" v-model="newSource">
+            </div>
+            <div class="form-group">
+                <input type="text" class="form-control" placeholder="{% trans 'Destination address' %}" v-model="newDestination">
+            </div>
+            <div class="form-group">
+                <button type="button" class="btn btn-primary" v-on:click="addAlias">{% trans "Add Alias" %}</button>
+            </div>
+            <div class="alert alert-danger" v-if="error">[[ error ]]</div>
+            <div class="alert alert-success" v-if="success">[[ success ]]</div>
+            <table class="table">
+                <thead>
+                    <tr><th>{% trans "Source" %}</th><th>{% trans "Destination" %}</th><th>{% trans "Actions" %}</th></tr>
+                </thead>
+                <tbody>
+                    <tr v-for="alias in aliases" :key="alias.source + alias.destination">
+                        <td>[[ alias.source ]]</td>
+                        <td>[[ alias.destination ]]</td>
+                        <td><button class="btn btn-danger btn-sm" v-on:click="deleteAlias(alias.source, alias.destination)">{% trans "Delete" %}</button></td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}
+{% block footer_scripts %}
+<script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+<script src="{% static 'emailAliasPlugin/email_aliases.js' %}"></script>
+{% endblock %}

--- a/emailAliasPlugin/tests.py
+++ b/emailAliasPlugin/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Add plugin tests if necessary

--- a/emailAliasPlugin/urls.py
+++ b/emailAliasPlugin/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('', views.alias_manager, name='email_alias_manager'),
+    path('fetch/', views.fetch_aliases, name='fetch_aliases'),
+    path('add/', views.add_alias, name='add_alias'),
+    path('delete/', views.delete_alias, name='delete_alias'),
+]

--- a/emailAliasPlugin/views.py
+++ b/emailAliasPlugin/views.py
@@ -1,0 +1,46 @@
+from django.shortcuts import render
+from django.http import HttpResponse
+from django.views.decorators.csrf import csrf_exempt
+import json
+from mailServer.models import Forwardings
+
+
+def alias_manager(request):
+    return render(request, 'emailAliasPlugin/email_aliases.html')
+
+
+@csrf_exempt
+def fetch_aliases(request):
+    if request.method != 'POST':
+        return HttpResponse(status=405)
+    data = [{'source': f.source, 'destination': f.destination} for f in Forwardings.objects.all()]
+    return HttpResponse(json.dumps({'aliases': data}), content_type='application/json')
+
+
+@csrf_exempt
+def add_alias(request):
+    if request.method != 'POST':
+        return HttpResponse(status=405)
+    payload = json.loads(request.body or '{}')
+    src = payload.get('source', '').strip()
+    dst = payload.get('destination', '').strip()
+    if not src or not dst:
+        return HttpResponse(json.dumps({'status': False, 'error': 'Invalid input'}),
+                            content_type='application/json')
+    if Forwardings.objects.filter(source=src, destination=dst).exists():
+        return HttpResponse(json.dumps({'status': False, 'error': 'Alias already exists'}),
+                            content_type='application/json')
+    Forwardings.objects.create(source=src, destination=dst)
+    return HttpResponse(json.dumps({'status': True, 'message': 'Alias created'}),
+                        content_type='application/json')
+
+
+@csrf_exempt
+def delete_alias(request):
+    if request.method != 'POST':
+        return HttpResponse(status=405)
+    payload = json.loads(request.body or '{}')
+    src = payload.get('source', '').strip()
+    dst = payload.get('destination', '').strip()
+    Forwardings.objects.filter(source=src, destination=dst).delete()
+    return HttpResponse(json.dumps({'status': True}), content_type='application/json')


### PR DESCRIPTION
## Summary
- create `emailAliasPlugin` to manage email aliases
- expose routes under `emailAliases/`
- enable plugin in settings and urls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845da7c6f208323b160d6524abaf42d